### PR TITLE
Implement mobilenetv2 with ONNX Runtime backend

### DIFF
--- a/onnx-mobilenetv2/Makefile
+++ b/onnx-mobilenetv2/Makefile
@@ -1,0 +1,9 @@
+MODEL_URL = https://github.com/onnx/models/raw/main/validated/vision/classification/mobilenet/model/mobilenetv2-12.onnx
+ONNX_PATH = models/mobilenetv2/1/model.onnx 
+
+
+build: $(ONNX_PATH)
+
+$(ONNX_PATH):
+	wget -O $@ $(MODEL_URL)
+

--- a/onnx-mobilenetv2/models/mobilenetv2/1/.gitignore
+++ b/onnx-mobilenetv2/models/mobilenetv2/1/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/onnx-mobilenetv2/models/mobilenetv2/config.pbtxt
+++ b/onnx-mobilenetv2/models/mobilenetv2/config.pbtxt
@@ -1,0 +1,12 @@
+platform: "onnxruntime_onnx"
+max_batch_size: 1
+
+instance_group [
+  {
+    count: 1
+    kind: KIND_CPU
+  }
+]
+
+parameters { key: "intra_op_thread_count" value: { string_value: "1" } }
+parameters { key: "inter_op_thread_count" value: { string_value: "1" } }


### PR DESCRIPTION
## Instructions

Run server:

```
docker run --rm --net host -v $(pwd)/models:/models nvcr.io/nvidia/tritonserver:24.06-py3 tritonserver --model-repository=/models
```

Run benchmark client:

```
docker run --rm --net host nvcr.io/nvidia/tritonserver:24.06-py3-sdk perf_analyzer -u localhost:8000 -m mobilenetv2 --concurrency-range 1:8
```

## Benchmark results
AWS EC2 instance type: c7a.2xlarge.

Let `m` be the number of model instances, `n` be the number of intra-op threads.

- Experiment 1: m=4, n=1
- Experiment 2: m=2, n=2
- Experiment 3: m=1, n=4


### Experiment 1

```
Concurrency: 1, throughput: 126.975 infer/sec, latency 7836 usec
Concurrency: 2, throughput: 245.791 infer/sec, latency 8093 usec
Concurrency: 3, throughput: 338.272 infer/sec, latency 8812 usec
Concurrency: 4, throughput: 425.694 infer/sec, latency 9337 usec
Concurrency: 5, throughput: 552.312 infer/sec, latency 9017 usec
Concurrency: 6, throughput: 539.899 infer/sec, latency 11064 usec
Concurrency: 7, throughput: 538.569 infer/sec, latency 12954 usec
Concurrency: 8, throughput: 541.96 infer/sec, latency 14715 usec
```

### Experiment 2

```
Concurrency: 1, throughput: 210.602 infer/sec, latency 4711 usec
Concurrency: 2, throughput: 401.039 infer/sec, latency 4948 usec
Concurrency: 3, throughput: 503.033 infer/sec, latency 5931 usec
Concurrency: 4, throughput: 494.162 infer/sec, latency 8057 usec
Concurrency: 5, throughput: 492.89 infer/sec, latency 10105 usec
Concurrency: 6, throughput: 493.183 infer/sec, latency 12126 usec
Concurrency: 7, throughput: 493.041 infer/sec, latency 14159 usec
Concurrency: 8, throughput: 493.265 infer/sec, latency 16178 usec
```


### Experiment 3

```
Concurrency: 1, throughput: 363.038 infer/sec, latency 2722 usec
Concurrency: 2, throughput: 485.889 infer/sec, latency 4082 usec
Concurrency: 3, throughput: 485.753 infer/sec, latency 6144 usec
Concurrency: 4, throughput: 485.815 infer/sec, latency 8201 usec
Concurrency: 5, throughput: 485.646 infer/sec, latency 10262 usec
Concurrency: 6, throughput: 485.301 infer/sec, latency 12327 usec
Concurrency: 7, throughput: 485.349 infer/sec, latency 14388 usec
Concurrency: 8, throughput: 485.169 infer/sec, latency 16451 usec
```